### PR TITLE
split off dev deps into devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,12 +9,14 @@
     "url"  : "https://github.com/benadida/node-client-sessions"
   },
   "dependencies" : {
-    "vows": "0.5.13",
     "cookies" : "https://github.com/benadida/cookies/tarball/d2f0f0b3",
+    "node-proxy": "0.5.2"
+  },
+  "devDependencies": {
+    "vows": "0.5.13",
     "express": "2.5.0",
     "tobi": "https://github.com/Cowboy-coder/tobi/tarball/fd733a3",
-    "zombie": "0.12.9",
-    "node-proxy": "0.5.2"
+    "zombie": "0.12.9"
   },
   "author" : {
     "name"  : "Ben Adida",


### PR DESCRIPTION
When someone uses this library, npm install grabs a lot of shit:

```
client-sessions@0.0.2 ./node_modules/client-sessions 
├── cookies@0.1.7
├── vows@0.5.13 (eyes@0.1.7)
├── node-proxy@0.5.2
├── express@2.5.0 (mkdirp@0.0.7 qs@0.4.0 mime@1.2.4 connect@1.7.3)
├── tobi@0.3.2 (qs@0.4.0 should@0.5.1 htmlparser@1.7.4 jsdom@0.2.10)
└── zombie@0.12.9
```

zombie, tobie, express, and vows are only needed during development.  npm install is smart enough to install devDependencies when you `npm install` in your checked out repo. 

This change should have zero impact to usability of the library, just make it lighter and easier to depend on.

some theory: http://blog.nodejitsu.com/package-dependencies-done-right
