### PR TITLE
Avoid creating an empty cookie on reads (fixes #14)

### DIFF
--- a/lib/client-sessions.js
+++ b/lib/client-sessions.js
@@ -78,7 +78,7 @@ Session.prototype = {
 
   setDuration: function(newDuration) {
     if (!this.loaded)
-      this.loadFromCookie();
+      this.loadFromCookie(true);
     this.dirty = true;
     this.duration = newDuration;
     this.createdAt = new Date().getTime();
@@ -181,7 +181,7 @@ Session.prototype = {
     }
   },
 
-  loadFromCookie: function() {
+  loadFromCookie: function(force_reset) {
     var cookie = this.cookies.get(this.opts.cookieName);
     if (cookie) {
       this.unbox(cookie);
@@ -190,10 +190,15 @@ Session.prototype = {
       if ((this.createdAt + this.duration) < new Date().getTime())
         this.reset();
     } else {
-      this.reset();
+      if (force_reset) {
+        this.reset();
+      } else {
+        return false; // didn't actually load the cookie
+      }
     }
 
     this.loaded = true;
+    return true;
   },
 
   // called to create a proxy that monitors the session
@@ -211,8 +216,10 @@ Session.prototype = {
       } else if (['setDuration'].indexOf(name) > -1) {
         return raw_session[name].bind(raw_session);
       } else {
-        if (!raw_session.loaded)
-          raw_session.loadFromCookie();
+        if (!raw_session.loaded) {
+          var didLoad = raw_session.loadFromCookie();
+          if (!didLoad) return null;
+        }
         return this.target[name];
       }
     };
@@ -222,7 +229,7 @@ Session.prototype = {
       // we have to load existing content, otherwise it will later override
       // the content that is written.
       if (!raw_session.loaded)
-        raw_session.loadFromCookie();
+        raw_session.loadFromCookie(true);
 
       this.target[name] = value;
       raw_session.dirty = true;
@@ -232,8 +239,10 @@ Session.prototype = {
     sessionHandler.delete = function(name) {
       // we have to load existing content, otherwise it will later override
       // the content that is written.
-      if (!raw_session.loaded)
-        raw_session.loadFromCookie();
+      if (!raw_session.loaded) {
+        var didLoad = raw_session.loadFromCookie();
+        if (!didLoad) return;
+      }
 
       delete this.target[name];
       raw_session.dirty = true;


### PR DESCRIPTION
I ran the vows tests and they all pass. I also manually inspected the headers to make sure that the bug I reported is fixed.
