### PR TITLE
Fix openssl warning for decipher input encoding

### DIFF
--- a/lib/client-sessions.js
+++ b/lib/client-sessions.js
@@ -1,4 +1,3 @@
-
 var Cookies = require("cookies");
 var Proxy = require("node-proxy");
 var Handler = require("./ProxyHandler.js");
@@ -128,7 +127,7 @@ function decode(opts, content) {
 
     // decrypt
     var cipher = crypto.createDecipheriv('aes256', opts.encryptionKey, iv);
-    var plaintext = cipher.update(ciphertext, 'utf8');
+    var plaintext = cipher.update(ciphertext, 'binary', 'utf8');
     plaintext += cipher.final('utf8');
 
     var cookieName = plaintext.substring(0, plaintext.indexOf(COOKIE_NAME_SEP));


### PR DESCRIPTION
Small fix for the following warning:

> node-crypto : Decipher .update encoding can be binary, hex or base64

Changed 2nd arg of [decipher.update](http://nodejs.org/api/crypto.html#crypto_cipher_update_data_input_encoding_output_encoding) to be 'binary' matching the encoding of the input Buffer object. Output remains 'utf8'.
