### PR TITLE
allow the client to specify a different request key name rather than for...

### DIFF
--- a/lib/client-sessions.js
+++ b/lib/client-sessions.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 var Cookies = require("cookies");
 var Proxy = require("node-proxy");
 var Handler = require("./ProxyHandler.js");
@@ -355,7 +359,7 @@ var cookieSession = function(opts) {
       return;
     }
 
-    req[opts.cookieName] = raw_session.monitor();
+    req[opts.requestKey || opts.cookieName] = raw_session.monitor();
 
     res.on('header', function() {
       raw_session.updateCookie();

--- a/test/all-test.js
+++ b/test/all-test.js
@@ -780,6 +780,33 @@ suite.addBatch({
   }
 });
 
+suite.addBatch({
+  "specifying requestKey different than cookieName": {
+    topic: function() {
+      var self = this;
+
+      var app = express.createServer();
+      app.use(cookieSessions({
+        cookieName: 'ooga_booga_momma',
+        requestKey: 'ses',
+        secret: 'yo'
+      }));
+
+      app.get('/foo', function(req, res) {
+        self.callback(null, req)
+      });
+
+      var browser = tobi.createBrowser(app);
+      browser.get("/foo", function(res, $){});
+    },
+    "session is defined as req[requestKey]": function(err, req) {
+      assert.isObject(req.ses);
+      assert.strictEqual(Object.keys(req.ses).length, 0);
+      assert.isUndefined(req.session);
+      assert.isUndefined(req.ooga_booga_momma);
+    }
+  }
+});
 
 suite.addBatch({
   "swapping two cookies": {


### PR DESCRIPTION
...cing them to use the cookie name.  This makes it much easier to migrate to client-sessions 0.3.x - issue #43
