### PR TITLE
make client-session self-aware

### DIFF
--- a/lib/client-sessions.js
+++ b/lib/client-sessions.js
@@ -348,7 +348,13 @@ var cookieSession = function(opts) {
   opts.encryptionKey = deriveKey(opts.secret, 'cookiesession-encryption');
   opts.signatureKey = deriveKey(opts.secret, 'cookiesession-signature');
 
+  const propertyName = opts.requestKey || opts.cookieName;
+
   return function(req, res, next) {
+    if (req[propertyName]) {
+      return next(); //self aware
+    }
+    
     var cookies = new Cookies(req, res);
     var raw_session;
     try {
@@ -359,7 +365,7 @@ var cookieSession = function(opts) {
       return;
     }
 
-    req[opts.requestKey || opts.cookieName] = raw_session.monitor();
+    req[propertyName] = raw_session.monitor();
 
     res.on('header', function() {
       raw_session.updateCookie();


### PR DESCRIPTION
useful for mounting express apps, so that multiple uses of
client-sessions don't clobber each other.
