### PR TITLE
Update the cookie expiry whenever duration or createdAt change

### DIFF
--- a/lib/client-sessions.js
+++ b/lib/client-sessions.js
@@ -180,14 +180,6 @@ function Session(req, res, cookies, opts) {
   this.res = res;
   this.cookies = cookies;
   this.opts = opts;
-  // support for maxAge
-  if (opts.cookie.maxAge) {
-    this.expires = new Date(new Date().getTime() + opts.cookie.maxAge);
-  } else {
-    // the cookie should expire when it becomes invalid
-    // we add an extra second because the conversion to a date truncates the milliseconds
-    this.expires = new Date(new Date().getTime() + opts.duration + 1000);
-  }
 
   this.content = {};
   this.loaded = false;
@@ -198,6 +190,13 @@ function Session(req, res, cookies, opts) {
   this.createdAt = null;
   this.duration = opts.duration;
 
+  // support for maxAge
+  if (opts.cookie.maxAge) {
+    this.expires = new Date(new Date().getTime() + opts.cookie.maxAge);
+  } else {
+    this.updateDefaultExpires();
+  }
+
   // here, we check that the security bits are set correctly
   var secure = res.socket.encrypted || req.connection.proxySecure;
   if (opts.cookie.secure && !secure)
@@ -205,6 +204,15 @@ function Session(req, res, cookies, opts) {
 }
 
 Session.prototype = {
+  updateDefaultExpires: function() {
+    if (!this.opts.cookie.maxAge) {
+      var time = this.createdAt || new Date().getTime();
+      // the cookie should expire when it becomes invalid
+      // we add an extra second because the conversion to a date truncates the milliseconds
+      this.expires = new Date(time + this.duration + 1000);
+    }
+  },
+
   clearContent: function(keysToPreserve) {
     var self = this;
     Object.keys(this.content).forEach(function(k) {
@@ -220,6 +228,7 @@ Session.prototype = {
     this.clearContent(keysToPreserve);
     this.createdAt = new Date().getTime();
     this.duration = this.opts.duration;
+    this.updateDefaultExpires();
     this.dirty = true;
     this.loaded = true;
   },
@@ -230,6 +239,7 @@ Session.prototype = {
     this.dirty = true;
     this.duration = newDuration;
     this.createdAt = new Date().getTime();
+    this.updateDefaultExpires();
   },
 
   // take the content and do the encrypt-and-sign
@@ -252,6 +262,7 @@ Session.prototype = {
 
     this.createdAt = unboxed.createdAt;
     this.duration = unboxed.duration;
+    this.updateDefaultExpires();
   },
 
   updateCookie: function() {


### PR DESCRIPTION
The cookie is reset everytime something in the session payload
changes. Whenever its reset, the original value of expires is
used.

This is good unless the duration or the creation time change. In
that case, we need to also update the cookie expiry to match the
expiry of the signed payload.
