### PR TITLE
Use actual Harmony proxies if present

### DIFF
--- a/lib/client-sessions.js
+++ b/lib/client-sessions.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 var Cookies = require("cookies");
-var Proxy = require("node-proxy");
+var Proxy_ = (typeof Proxy !== 'undefined') ? Proxy : require("node-proxy");
 var Handler = require("./ProxyHandler.js");
 var crypto = require("crypto");
 
@@ -357,7 +357,7 @@ Session.prototype = {
       raw_session.dirty = true;
     };
 
-    var proxySession = Proxy.create(sessionHandler);
+    var proxySession = Proxy_.create(sessionHandler);
     return proxySession;
   }
 };


### PR DESCRIPTION
`node --harmony` enables actual Harmony proxies and using those is
preferable.
