### PR TITLE
Don't assume the existence of res.socket

### DIFF
--- a/lib/client-sessions.js
+++ b/lib/client-sessions.js
@@ -203,7 +203,7 @@ function Session(req, res, cookies, opts) {
   }
 
   // here, we check that the security bits are set correctly
-  var secure = res.socket.encrypted || req.connection.proxySecure;
+  var secure = (res.socket && res.socket.encrypted) || req.connection.proxySecure;
   if (opts.cookie.secure && !secure)
     throw "you cannot have a secure cookie unless the socket is secure or you declare req.connection.proxySecure to be true.";
 }
@@ -416,7 +416,7 @@ var cookieSession = function(opts) {
       raw_session = new Session(req, res, cookies, opts);
     } catch (x) {
       // this happens only if there's a big problem
-      process.nextTick(function() {next("error: " + x.toString());});
+      process.nextTick(function() {next("client-sessions error: " + x.toString());});
       return;
     }
 


### PR DESCRIPTION
We were getting this error `TypeError: Cannot read property 'encrypted' of null` and tracked it down to this code. 

Added a check to ensure that res.socket exists. Also made the source of these errors a bit clearer to save the next person a couple of hours...
