### PR TITLE
Remove dependency on express/connect emitted event

### DIFF
--- a/lib/client-sessions.js
+++ b/lib/client-sessions.js
@@ -422,10 +422,10 @@ var cookieSession = function(opts) {
 
     req[propertyName] = raw_session.monitor();
 
-    var writeHead = res.writeHead.bind(res)
+    var writeHead = res.writeHead;
     res.writeHead = function () {
       raw_session.updateCookie();
-      return writeHead.apply(res, arguments)
+      return writeHead.apply(res, arguments);
     }
 
     next();


### PR DESCRIPTION
Instead of listening for the `header` event, which is something
express/connect provides, hijack `writeHead` which gets called
implicitly (or explicitly, if the user wants) on every response.

This will allow people to use `client-sessions` outside of the 
context of an express/connect app (which is exactly what I'm
trying to do!)

Passed all tests locally. Sorry about that one whitespace diff

/cc @thisandagain
