### PR TITLE
Return undefined from util.decode on more invalid inputs

### DIFF
--- a/lib/client-sessions.js
+++ b/lib/client-sessions.js
@@ -263,16 +263,35 @@ function decode(opts, content) {
 
   setupKeys(opts);
 
-  var iv = base64urldecode(components[0]);
-  var ciphertext = base64urldecode(components[1]);
+  var iv;
+  var ciphertext;
+  var hmac;
+
+  try {
+    iv = base64urldecode(components[0]);
+    ciphertext = base64urldecode(components[1]);
+    hmac = base64urldecode(components[4]);
+  } catch (ignored) {
+    cleanup();
+    return;
+  }
+
   var createdAt = parseInt(components[2], 10);
   var duration = parseInt(components[3], 10);
-  var hmac = base64urldecode(components[4]);
 
   function cleanup() {
-    zeroBuffer(iv);
-    zeroBuffer(ciphertext);
-    zeroBuffer(hmac);
+    if (iv) {
+      zeroBuffer(iv);
+    }
+
+    if (ciphertext) {
+      zeroBuffer(ciphertext);
+    }
+
+    if (hmac) {
+      zeroBuffer(hmac);
+    }
+
     if (expectedHmac) { // declared below
       zeroBuffer(expectedHmac);
     }

--- a/test/all-test.js
+++ b/test/all-test.js
@@ -863,6 +863,13 @@ suite.addBatch({
       assert.isObject(decodedReal);
       var decodedFake = cookieSessions.util.decode({cookieName: 'session', secret: 'yo'}, encodedFake);
       assert.isUndefined(decodedFake);
+    },
+    "decode - invalid input" : function(err, req){
+        var notEnoughComponents = 'LVB3G2lnPF75RzsT9mz7jQ.RT1Lcq0dOJ_DMRHyWJ4NZPjBXr2WzkFcUC4NO78gbCQ.1371704898483.5000';
+        assert.isUndefined(cookieSessions.util.decode({cookieName: 'session', secret: 'yo'}, notEnoughComponents));
+
+        var invalidBase64 = 'LVB3G2lnPF75RzsT9mz7jQ.RT1Lcq0dOJ_DMRHyWJ4NZPjBXr2WzkFcUC4NO78gb.1371704898483.5000.ILEusgnajT1sqCWLuzaUt-HFn2KPjYNd38DhI7aRCb9';
+        assert.isUndefined(cookieSessions.util.decode({cookieName: 'session', secret: 'yo'}, invalidBase64));
     }
   }
 });


### PR DESCRIPTION
Specifically, on inputs with components that are invalid base64. Previously, such input would produce an exception, which is inconsistent with the behavior for other forms of invalid input (wrong number of components, wrong IV length, invalid JSON).
