### PR TITLE
added `destroy` as an alias for `reset` to have compatibility with other...

### DIFF
--- a/lib/client-sessions.js
+++ b/lib/client-sessions.js
@@ -421,6 +421,11 @@ Session.prototype = {
     this.loaded = true;
   },
 
+  // alias for `reset` function for compatibility
+  destroy: function(){
+    this.reset();
+  },
+
   setDuration: function(newDuration, ephemeral) {
     if (ephemeral && this.opts.cookie.maxAge) {
       throw new Error("you cannot have an ephemeral cookie with a maxAge.");


### PR DESCRIPTION
I added this alias to keep compatibility with express-session which is using `destroy` instead of `reset` to invalidate to session. This will make this session store swappable for other libs. 
