### PR TITLE
Exporting the destroy() method on session objects.

### DIFF
--- a/lib/client-sessions.js
+++ b/lib/client-sessions.js
@@ -527,6 +527,10 @@ Object.defineProperty(Session.prototype, 'content', {
       enumerable: false,
       value: this.reset.bind(this)
     });
+    Object.defineProperty(value, 'destroy', {
+      enumerable: false,
+      value: this.destroy.bind(this)
+    });
     Object.defineProperty(value, 'setDuration', {
       enumerable: false,
       value: this.setDuration.bind(this)


### PR DESCRIPTION
This is a follow up to PR #89. PR #89 added the destroy() method which adds compatibility for other session APIs, but didn't export the function.

This PR will fix that issue complete, by properly exporting the destroy method.

It would be awesome if you guys could merge this and cut a release, I maintain a library which depends on this, and it's quite annoying right now ><
