### PR TITLE
pass an Error to `next`, not a string

### DIFF
--- a/lib/client-sessions.js
+++ b/lib/client-sessions.js
@@ -602,7 +602,7 @@ function clientSessionFactory(opts) {
     } catch (x) {
       // this happens only if there's a big problem
       process.nextTick(function() {
-        next("client-sessions error: " + x.toString());
+        next(new Error("client-sessions error: " + x.toString()));
       });
       return;
     }


### PR DESCRIPTION
This was breaking convention, and could be problematic for code that
assumes errors are correctly passed around, not strings.
