### PR TITLE
Implement cookie cleanup

### DIFF
--- a/lib/client-sessions.js
+++ b/lib/client-sessions.js
@@ -360,6 +360,7 @@ function Session(req, res, cookies, opts) {
   this.json = JSON.stringify(this._content);
   this.loaded = false;
   this.dirty = false;
+  this.toCleanup = false;
 
   // no need to initialize it, loadFromCookie will do
   // via reset() or unbox()
@@ -426,6 +427,11 @@ Session.prototype = {
     this.reset();
   },
 
+  cleanup: function(){
+    this.reset();
+    this.toCleanup = true;
+  },
+
   setDuration: function(newDuration, ephemeral) {
     if (ephemeral && this.opts.cookie.maxAge) {
       throw new Error("you cannot have an ephemeral cookie with a maxAge.");
@@ -467,6 +473,19 @@ Session.prototype = {
   },
 
   updateCookie: function() {
+    if (this.toCleanup) {
+      // Force delete of cookie
+      delete this.opts.cookie.maxAge;
+      this.opts.cookie.expires = new Date(0);
+      try {
+        this.cookies.set(this.opts.cookieName, '', this.opts.cookie);
+      } catch (x) {
+        // this really shouldn't happen. Right now it happens if secure is set
+        // but cookies can't determine that the connection is secure.
+      }
+      return;
+    }
+
     if (this.isDirty()) {
       // support for adding/removing cookie expires
       this.opts.cookie.expires = this.expires;
@@ -531,11 +550,16 @@ Object.defineProperty(Session.prototype, 'content', {
       enumerable: false,
       value: this.destroy.bind(this)
     });
+    Object.defineProperty(value, 'cleanup', {
+      enumerable: false,
+      value: this.cleanup.bind(this)
+    });
     Object.defineProperty(value, 'setDuration', {
       enumerable: false,
       value: this.setDuration.bind(this)
     });
     this._content = value;
+    this.toCleanup = false;
   }
 });
 


### PR DESCRIPTION
Allow user to unset cookies from the browser.

```
req.session.cleanup();
```
will trigger:
```
Set-Cookie: session=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; httponly
```
Forcing cookie to be deleted from browser.