### PR TITLE
Support same site cookie flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "vows": "0.8.1",
-    "express": "2.5.0",
+    "express": "4.15.2",
     "request": "2.81.0"
   },
   "author" : {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "vows": "0.8.1",
     "express": "2.5.0",
-    "request": "2.42.0"
+    "request": "2.81.0"
   },
   "author" : {
     "name"  : "Ben Adida",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "cookies" : "0.5.0"
   },
   "devDependencies": {
-    "vows": "0.7.0",
+    "vows": "0.8.1",
     "express": "2.5.0",
     "request": "2.42.0"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url"  : "https://github.com/mozilla/node-client-sessions"
   },
   "dependencies" : {
-    "cookies" : "0.5.0"
+    "cookies" : "^0.7.0"
   },
   "devDependencies": {
     "vows": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -25,9 +25,6 @@
   "engines": {
     "node": ">= 0.8.0"
   },
-  "licenses": {
-    "type": "MPL 2.0",
-    "url": "https://raw.github.com/mozilla/node-client-sessions/master/LICENSE"
-  },
+  "license": "MPL-2.0",
   "bugs": "https://github.com/mozilla/node-client-sessions/issues"
 }

--- a/test/all-test.js
+++ b/test/all-test.js
@@ -1240,6 +1240,37 @@ suite.addBatch({
   }
 });
 
+suite.addBatch({
+  "sameSite cookie": {
+    topic: function() {
+      var self = this;
+      var app = express();
+
+      app.use(cookieSessions({
+        cookieName: 'session',
+        secret: 'yo',
+        activeDuration: 0,
+        cookie: {
+          sameSite: 'lax'
+        }
+      }));
+
+      app.get("/foo", function(req, res) {
+        req.session.foo = 'foobar';
+        res.send("hello");
+      });
+
+      var browser = createBrowser(app);
+      browser.get("/foo", function(res, $) {
+        self.callback(null, res);
+      });
+    },
+    "has samesite attribute": function(err, res) {
+      assert.match(res.headers['set-cookie'][0], /samesite=lax/, "cookie uses samesite");
+    }
+  }
+});
+
 var sixtyFourByteKey = new Buffer(
   '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
   'binary'

--- a/test/all-test.js
+++ b/test/all-test.js
@@ -27,7 +27,7 @@ function create_app() {
     }
   });
 
-  var app = express.createServer();
+  var app = express();
   app.use(middleware);
 
   // set up a second cookie storage middleware
@@ -59,7 +59,7 @@ function createBrowser(server) {
         throw new TypeError('callback must be a function');
       }
       // Ensure that server is ready to take connections
-      if (server && !server._handle) {
+      if (server && !server.__listening) {
         (server.__deferred = server.__deferred || []).push([url, options, callback]);
         if (!server.__started) {
           server.listen(server.__port = ++startingPort, '127.0.0.1', function(){
@@ -68,6 +68,7 @@ function createBrowser(server) {
                 browser.get.apply(browser, args);
               });
             });
+            server.__listening = true;
           });
           server.__started = true;
         }
@@ -438,7 +439,7 @@ suite.addBatch({
 
 function create_app_with_duration() {
   // simple app
-  var app = express.createServer();
+  var app = express();
   app.use(cookieSessions({
     cookieName: 'session',
     secret: 'yo',
@@ -605,7 +606,7 @@ suite.addBatch({
 
 function create_app_with_duration_modification() {
   // simple app
-  var app = express.createServer();
+  var app = express();
 
   app.use(cookieSessions({
     cookieName: 'session',
@@ -801,7 +802,7 @@ function create_app_with_secure(firstMiddleware) {
     }
   });
 
-  var app = express.createServer();
+  var app = express();
   if (firstMiddleware)
     app.use(firstMiddleware);
 
@@ -953,7 +954,7 @@ suite.addBatch({
     topic: function() {
       var self = this;
 
-      var app = express.createServer();
+      var app = express();
       app.use(cookieSessions({
         cookieName: 'ooga_booga_momma',
         activeDuration: 0,
@@ -1030,7 +1031,7 @@ suite.addBatch({
     topic: function() {
       var self = this;
 
-      var app = express.createServer();
+      var app = express();
       app.use(cookieSessions({
         cookieName: 'session',
         duration: 50000,
@@ -1062,7 +1063,7 @@ suite.addBatch({
     topic: function() {
       var self = this;
 
-      var app = express.createServer();
+      var app = express();
       app.use(cookieSessions({
         cookieName: 'session',
         duration: 500,
@@ -1098,7 +1099,7 @@ suite.addBatch({
   },
   "active user with session close to expiration": {
     topic: function() {
-      var app = express.createServer();
+      var app = express();
       var self = this;
       app.use(cookieSessions({
         cookieName: 'session',
@@ -1152,7 +1153,7 @@ suite.addBatch({
     topic: function() {
       var self = this;
 
-      var app = express.createServer();
+      var app = express();
       app.use(cookieSessions({
         cookieName: 'session',
         duration: 5000,
@@ -1196,7 +1197,7 @@ suite.addBatch({
     topic: function() {
       var self = this;
 
-      var app = express.createServer();
+      var app = express();
       app.use(cookieSessions({
         cookieName: 'session',
         duration: 50000,


### PR DESCRIPTION
hi there :wave:

thanks for a very helpful lib. i get the impression it's between owners at the moment but i figured i'd open this anyway. my aim here was to gain support for the `sameSite` cookie flag [[info]](https://scotthelme.co.uk/csrf-is-dead/) [[spec]](https://tools.ietf.org/html/draft-ietf-httpbis-cookie-same-site-00) available in [chrome v51+](https://www.chromestatus.com/feature/4672634709082112) and [others](http://caniuse.com/#search=SameSite). i ended up upgrading the test dependencies along the way. happy to make adjustments :+1:

-matt