### PR TITLE
secureProxy is deprecated in cookies

### DIFF
--- a/lib/client-sessions.js
+++ b/lib/client-sessions.js
@@ -594,8 +594,12 @@ function clientSessionFactory(opts) {
     if (propertyName in req) {
       return next(); //self aware
     }
-
-    var cookies = new Cookies(req, res);
+    var options
+    if (opts.cookie.secureProxy) {
+      options = { secure: opts.cookie.secureProxy }
+      delete opts.cookie.secureProxy
+    }
+    var cookies = new Cookies(req, res, options);
     var rawSession;
     try {
       rawSession = new Session(req, res, cookies, opts);


### PR DESCRIPTION
The `secureProxy`  option has been deprecated by the `cookie` module when it is passed as a cookie option during `cookies.set()`. The module recommends passing the secureProxy option in the constructor instead.

https://github.com/pillarjs/cookies/commit/c7cf922795020bcfd284103d5c8ad792d4261699

This PR implements that recommendation.