### PR TITLE
Session extended for fixed activeDuration from now

### DIFF
--- a/lib/client-sessions.js
+++ b/lib/client-sessions.js
@@ -492,7 +492,7 @@ Session.prototype = {
         this.reset();
       // if expiration is soon, push back a few minutes to not interrupt user
       } else if (expiresAt - now < this.activeDuration) {
-        this.createdAt += this.activeDuration;
+        this.createdAt = (now + this.activeDuration) - this.duration;
         this.dirty = true;
         this.updateDefaultExpires();
       }


### PR DESCRIPTION
Great stuff! Thanks!

This proposal might help bring consistency on how long the session is extended from the current time.
Currently the `createdAt` is update to extend by `activeDuration`, which in-effect extends the session for a varied time from now, i.e. anywhere between `activeDuration` to `duration`. This proposal would extend the session for exactly the `activeDuration` from now.