### PR TITLE
Use Buffer.from, Buffer.alloc instead of deprecated constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ output into a `Buffer`:
 ```js
 function loadKeyFromStore(name) {
   var text = myConfig.keys[name];
-  return new Buffer(text, 'base64');
+  return Buffer.from(text, 'base64');
 }
 ```
 

--- a/lib/client-sessions.js
+++ b/lib/client-sessions.js
@@ -62,14 +62,14 @@ function base64urldecode(arg) {
     default:
       throw new Error("Illegal base64url string!");
   }
-  return new Buffer(s, 'base64'); // Standard base64 decoder
+  return Buffer.from(s, 'base64'); // Standard base64 decoder
 }
 
 function forceBuffer(binaryOrBuffer) {
   if (Buffer.isBuffer(binaryOrBuffer)) {
     return binaryOrBuffer;
   } else {
-    return new Buffer(binaryOrBuffer, 'binary');
+    return Buffer.from(binaryOrBuffer, 'binary');
   }
 }
 
@@ -172,7 +172,7 @@ function hmacInit(algo, key) {
       var result = forceBuffer(origDigest.call(this));
       // Throw away the second half of the 512-bit result, leaving the first
       // 256-bits.
-      var truncated = new Buffer(N);
+      var truncated = Buffer.alloc(N);
       result.copy(truncated, 0, 0, N);
       zeroBuffer(result);
       return truncated;
@@ -215,7 +215,7 @@ function encode(opts, content, duration, createdAt){
   var iv = crypto.randomBytes(16);
 
   // encrypt with encryption key
-  var plaintext = new Buffer(
+  var plaintext = Buffer.from(
     opts.cookieName + COOKIE_NAME_SEP + JSON.stringify(content),
     'utf8'
   );

--- a/test/all-test.js
+++ b/test/all-test.js
@@ -1317,7 +1317,7 @@ suite.addBatch({
   }
 });
 
-var sixtyFourByteKey = new Buffer(
+var sixtyFourByteKey = Buffer.from(
   '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
   'binary'
 );
@@ -1344,8 +1344,8 @@ function testHmac(algo) {
       signatureAlgorithm: algo,
       signatureKey: sixtyFourByteKey
     };
-    var iv = new Buffer('01234567890abcdef','binary'); // 128-bits
-    var ciphertext = new Buffer('0123456789abcdef0123','binary');
+    var iv = Buffer.from('01234567890abcdef','binary'); // 128-bits
+    var ciphertext = Buffer.from('0123456789abcdef0123','binary');
     var duration = 876543210;
     var createdAt = 1234567890;
 


### PR DESCRIPTION
Simply remove all the usages of the deprecated buffer constructor.
Using Buffer.from and Buffer.allow instead.