### PR TITLE
Cookies dependency update to 0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url"  : "https://github.com/mozilla/node-client-sessions"
   },
   "dependencies" : {
-    "cookies" : "^0.7.0"
+    "cookies" : "^0.8.0"
   },
   "devDependencies": {
     "vows": "0.8.1",


### PR DESCRIPTION
Update to Cookies 0.8.0 to support "none" in sameSite option and other fixes.